### PR TITLE
Fix newline cursor issue

### DIFF
--- a/Sources/TextView/Coordinator.swift
+++ b/Sources/TextView/Coordinator.swift
@@ -111,12 +111,13 @@ extension TextView.Representable.Coordinator {
     }
 
     private func recalculateHeight() {
-        let newSize = textView.sizeThatFits(CGSize(width: textView.frame.width, height: .greatestFiniteMagnitude))
-        guard calculatedHeight.wrappedValue != newSize.height else { return }
+        let threshold = 0.00001
+        textView.sizeToFit()
+        let updatedHeight = textView.bounds.height
+        guard abs(calculatedHeight.wrappedValue - updatedHeight) > threshold else { return }
 
         DispatchQueue.main.async { // call in next render cycle.
-            self.calculatedHeight.wrappedValue = newSize.height
+            self.calculatedHeight.wrappedValue = updatedHeight
         }
     }
-
 }


### PR DESCRIPTION
*Have you read the [Contributing Guidelines](https://github.com/shaps80/.github/blob/master/CONTRIBUTING.md)?*

## Issue

When you input a multiline string and insert a new line somewhere in the input, the cursor will stay on the previous line whereas the height of the text view has increased (see attachment)

Step or reproduce

1.  Input a random string
2. Insert a new line by pressing the return key
3. you can see the cursor stayed at the previous line, but the new line has been added.

<img width="506" alt="image" src="https://user-images.githubusercontent.com/8701790/177024250-f7e0e533-66f3-41d5-a91e-4fa3765a3b91.png">


## Describe your changes

1. Use `sizeToFit` to get the accurate textView size.
2. Only update the textView size if the diff is larger than the threshold (since it is not that good to use `==` for floating value comparison)

<img width="506" alt="image" src="https://user-images.githubusercontent.com/8701790/177024335-34015a87-55ab-42cd-8e84-9171ec6f865e.png">


*Clearly and concisely describe what's in this pull request. Include screenshots, if necessary.*
