### PR TITLE
Moved attributedText setter to makeUIView

### DIFF
--- a/Sources/TextView/Coordinator.swift
+++ b/Sources/TextView/Coordinator.swift
@@ -68,7 +68,6 @@ extension TextView.Representable {
 extension TextView.Representable.Coordinator {
 
     func update(representable: TextView.Representable) {
-        textView.attributedText = representable.text
         textView.font = representable.font
         textView.adjustsFontForContentSizeCategory = true
         textView.textColor = representable.foregroundColor

--- a/Sources/TextView/Representable.swift
+++ b/Sources/TextView/Representable.swift
@@ -26,7 +26,8 @@ extension TextView {
         var onCommit: (() -> Void)?
 
         func makeUIView(context: Context) -> UIKitTextView {
-            context.coordinator.textView
+            context.coordinator.textView.attributedText = text
+            return context.coordinator.textView
         }
 
         func updateUIView(_ view: UIKitTextView, context: Context) {


### PR DESCRIPTION
*Have you read the [Contributing Guidelines](https://github.com/shaps80/.github/blob/master/CONTRIBUTING.md)?*

Issue #
https://github.com/SwiftUI-Plus/TextView/issues/5#issue-1161458839

## Describe your changes

*Clearly and concisely describe what's in this pull request. Include screenshots, if necessary.*

By moving the attributedText setter from updateUIView to makeUIView, the cursor will no longer jump to the end upon editing text.
